### PR TITLE
(1.20.1) Minor fixes, mostly derrick-related

### DIFF
--- a/src/main/java/flaxbeard/immersivepetroleum/common/IPRegisters.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/IPRegisters.java
@@ -9,6 +9,7 @@ import blusunrize.immersiveengineering.api.multiblocks.blocks.component.IMultibl
 import blusunrize.immersiveengineering.api.multiblocks.blocks.component.RedstoneControl;
 import blusunrize.immersiveengineering.api.multiblocks.blocks.logic.IMultiblockLogic;
 import blusunrize.immersiveengineering.api.multiblocks.blocks.logic.IMultiblockState;
+import blusunrize.immersiveengineering.api.multiblocks.blocks.registry.MultiblockItem;
 import blusunrize.immersiveengineering.common.blocks.IEBlockInterfaces;
 import blusunrize.immersiveengineering.common.blocks.MultiblockBEType;
 import blusunrize.immersiveengineering.common.blocks.multiblocks.component.MultiblockGui;
@@ -16,6 +17,7 @@ import blusunrize.immersiveengineering.common.register.IEMenuTypes;
 import com.google.common.collect.ImmutableSet;
 import flaxbeard.immersivepetroleum.ImmersivePetroleum;
 import flaxbeard.immersivepetroleum.common.blocks.IPBlockBase;
+import flaxbeard.immersivepetroleum.common.blocks.IPMultiblockBase;
 import flaxbeard.immersivepetroleum.common.util.IPEffects.IPEffect;
 import flaxbeard.immersivepetroleum.common.util.ResourceUtils;
 import net.minecraft.core.BlockPos;
@@ -112,7 +114,10 @@ public class IPRegisters{
 		MultiblockBuilder<S> builder = new MultiblockBuilder<>(logic, name)
 				.structure(structure)
 				.defaultBEs(TE_REGISTER)
-				.defaultBlock(BLOCK_REGISTER, ITEM_REGISTER, prop);
+				.customBlock(BLOCK_REGISTER, ITEM_REGISTER,
+						mb -> new IPMultiblockBase<>(prop, mb),
+						MultiblockItem::new);
+				//.defaultBlock(BLOCK_REGISTER, ITEM_REGISTER, prop);
 
 		if(extras != null){
 			extras.accept(builder);

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/IPMultiblockBase.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/IPMultiblockBase.java
@@ -1,0 +1,69 @@
+package flaxbeard.immersivepetroleum.common.blocks;
+
+import blusunrize.immersiveengineering.api.IEProperties;
+import blusunrize.immersiveengineering.api.multiblocks.blocks.MultiblockRegistration;
+import blusunrize.immersiveengineering.api.multiblocks.blocks.logic.IMultiblockBE;
+import blusunrize.immersiveengineering.api.multiblocks.blocks.logic.IMultiblockState;
+import blusunrize.immersiveengineering.api.multiblocks.blocks.registry.MultiblockPartBlock;
+import flaxbeard.immersivepetroleum.common.IPContent;
+import net.minecraft.core.BlockPos;
+import net.minecraft.world.entity.LivingEntity;
+import net.minecraft.world.level.LevelReader;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.entity.BlockEntity;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+
+import javax.annotation.Nonnull;
+
+//This serves to replace the "default" registered block that makes up the multiblocks.
+public class IPMultiblockBase<T extends IMultiblockState> extends MultiblockPartBlock<T> {
+
+    //the multiblock field is private so we save it here to reference it later on.
+    private final MultiblockRegistration<T> multiblock;
+
+    public IPMultiblockBase(BlockBehaviour.Properties properties, MultiblockRegistration<T> multiblock){
+        super(properties, multiblock);
+        this.multiblock = multiblock;
+    }
+
+    /*
+    Normally this would be split up between the block and the block entities
+    Instead we do everything here. You can't even register custom tile entities anymore.
+     */
+    @Override
+    public boolean isLadder(BlockState state, LevelReader level, BlockPos pos, LivingEntity entity){
+        BlockEntity be = level.getBlockEntity(pos);
+        //This is kinda ugly, but it's all we need to get closest to the original implementation.
+        if(!(be instanceof IMultiblockBE<?> multiblockBE)) return false;
+        BlockPos posMb = multiblockBE.getHelper().getPositionInMB();
+        int bX = posMb.getX();
+        int bY = posMb.getY();
+        int bZ = posMb.getZ();
+        //No, a switch won't accept this.
+        if(multiblock == IPContent.Multiblock.COKERUNIT){
+            return ((bX == 8 && bZ == 2) && (bY >= 5 && bY <= 13)) //Primary Ladder
+                    || ((bX == 7 && bZ == 2) && (bY >= 15 && bY <= 21)); //Secondary Ladder
+        }
+        if(multiblock == IPContent.Multiblock.DERRICK){
+            return (bY >= 0 && bY <= 2 && bX == 0 && bZ == 2);
+        }
+        if(multiblock == IPContent.Multiblock.DISTILLATIONTOWER){
+            return (bY > 0 && bX == 2 && bZ == 0);
+        }
+        if(multiblock == IPContent.Multiblock.OILTANK){
+            return (bX == 3 && bZ == 0);
+        }
+        return false;
+    }
+
+    //Without this, the constructor of MultiblockPartBlock will throw an exception and initialization will actually explode.
+    @Override
+    protected void createBlockStateDefinition(@Nonnull StateDefinition.Builder<Block, BlockState> builder){
+        super.createBlockStateDefinition(builder);
+        builder.add(IEProperties.MIRRORED);
+    }
+
+
+}

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/multiblocks/logic/DerrickLogic.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/multiblocks/logic/DerrickLogic.java
@@ -23,8 +23,11 @@ import blusunrize.immersiveengineering.api.multiblocks.blocks.util.CapabilityPos
 import blusunrize.immersiveengineering.api.multiblocks.blocks.util.RelativeBlockFace;
 import blusunrize.immersiveengineering.api.multiblocks.blocks.util.ShapeType;
 import blusunrize.immersiveengineering.api.multiblocks.blocks.util.StoredCapability;
+import blusunrize.immersiveengineering.common.blocks.metal.FluidPipeBlockEntity;
+import blusunrize.immersiveengineering.common.blocks.metal.FluidPumpBlockEntity;
 import blusunrize.immersiveengineering.common.blocks.multiblocks.blockimpl.InitialMultiblockContext;
 import blusunrize.immersiveengineering.common.fluids.ArrayFluidHandler;
+import blusunrize.immersiveengineering.common.register.IEBlockEntities;
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirHandler;
 import flaxbeard.immersivepetroleum.api.reservoir.ReservoirIsland;
 import flaxbeard.immersivepetroleum.client.ClientProxy;
@@ -146,7 +149,7 @@ public class DerrickLogic implements IMultiblockLogic<DerrickLogic.State>, IServ
                 level.getRawLevel().addParticle(new BlockParticleOption(ParticleTypes.BLOCK, PARTICLESTATES[r]), x, y, z, xa, ya, za);
             }
         }
-
+        //FIXME: This is not the correct blockpos. When the particles do show, they show at the base, in a corner. Probably need to add a position offset from there.
         if(state.spilling){
             ClientProxy.spawnSpillParticles(level.getRawLevel(), level.getAbsoluteOrigin(), state.fluidSpilled, 5, 1.25F, state.clientFlow);
         }
@@ -411,13 +414,12 @@ public class DerrickLogic implements IMultiblockLogic<DerrickLogic.State>, IServ
             BlockEntity target = level.getRawLevel().getBlockEntity(outPos);
             if (target != null)
             {
+                boolean iePipe = level.getRawLevel().getBlockEntity(outPos) instanceof IFluidPipe;
                 LazyOptional<IFluidHandler> output = target.getCapability(ForgeCapabilities.FLUID_HANDLER, mirrored ? front.getClockWise() : front.getCounterClockWise());
                 state.spilling = output.map(out -> {
-                    FluidStack fluid = FluidHelper.copyFluid(extracted, extracted.getAmount());
+                    FluidStack fluid = FluidHelper.copyFluid(extracted, extracted.getAmount(), iePipe);
                     int accepted = out.fill(fluid, IFluidHandler.FluidAction.SIMULATE);
                     if(accepted > 0){
-                        boolean iePipe = level.getRawLevel().getBlockEntity(outPos) instanceof IFluidPipe;
-
                         int drained = out.fill(FluidHelper.copyFluid(fluid, Math.min(fluid.getAmount(), accepted), iePipe), IFluidHandler.FluidAction.EXECUTE);
                         return fluid.getAmount() - drained > 0;
                     }else{
@@ -586,7 +588,7 @@ public class DerrickLogic implements IMultiblockLogic<DerrickLogic.State>, IServ
 
             ContainerHelper.saveAllItems(nbt, this.inventory);
         }
-
+        //TODO: Looks like these need to be changed to get the spill to show properly.
         @Override
         public void readSyncNBT(CompoundTag nbt)
         {

--- a/src/main/java/flaxbeard/immersivepetroleum/common/blocks/multiblocks/logic/DerrickLogic.java
+++ b/src/main/java/flaxbeard/immersivepetroleum/common/blocks/multiblocks/logic/DerrickLogic.java
@@ -149,9 +149,8 @@ public class DerrickLogic implements IMultiblockLogic<DerrickLogic.State>, IServ
                 level.getRawLevel().addParticle(new BlockParticleOption(ParticleTypes.BLOCK, PARTICLESTATES[r]), x, y, z, xa, ya, za);
             }
         }
-        //FIXME: This is not the correct blockpos. When the particles do show, they show at the base, in a corner. Probably need to add a position offset from there.
         if(state.spilling){
-            ClientProxy.spawnSpillParticles(level.getRawLevel(), level.getAbsoluteOrigin(), state.fluidSpilled, 5, 1.25F, state.clientFlow);
+            ClientProxy.spawnSpillParticles(level.getRawLevel(), level.toAbsolute(IPContent.Multiblock.DERRICK.masterPosInMB()), state.fluidSpilled, 5, 1.25F, state.clientFlow);
         }
     }
 
@@ -588,19 +587,21 @@ public class DerrickLogic implements IMultiblockLogic<DerrickLogic.State>, IServ
 
             ContainerHelper.saveAllItems(nbt, this.inventory);
         }
-        //TODO: Looks like these need to be changed to get the spill to show properly.
+        //TODO: I don't think this is the proper method. But looks like it works.
         @Override
         public void readSyncNBT(CompoundTag nbt)
         {
-            this.drilling = nbt.getBoolean("drilling");
-            this.spilling = nbt.getBoolean("spilling");
+            readSaveNBT(nbt);
+            //this.drilling = nbt.getBoolean("drilling");
+            //this.spilling = nbt.getBoolean("spilling");
         }
 
         @Override
         public void writeSyncNBT(CompoundTag nbt)
         {
-            nbt.putBoolean("drilling", this.drilling);
-            nbt.putBoolean("spilling", this.spilling);
+            writeSaveNBT(nbt);
+            //nbt.putBoolean("drilling", this.drilling);
+            //nbt.putBoolean("spilling", this.spilling);
         }
 
         private int getReservoirFlow(){


### PR DESCRIPTION
- Reimplemented functionality to the ladders on the multiblock models.
- Fixed an issue where derrick throughput was limited to 50 mb/t with an IE pipe on the output.
- Fixed derrick spill particles not showing.